### PR TITLE
ypresto/SwiftLintXcode#11 always call autocorrect with --format option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SwiftLintXcode
 
 An Xcode plug-in to format your code using [SwiftLint](https://github.com/realm/SwiftLint).
 
-Runs `swiftlint autocorrect --path CURRENT_FILE` before \*.swift file is saved.
+Runs `swiftlint autocorrect --format --path CURRENT_FILE` before \*.swift file is saved.
 
 ![Screenshot](https://cloud.githubusercontent.com/assets/400558/14304460/d2a133dc-fbed-11e5-9573-2c21cce699e0.png)
 

--- a/SwiftLintXcode/Formatter.swift
+++ b/SwiftLintXcode/Formatter.swift
@@ -80,7 +80,7 @@ final class Formatter {
             let swiftlintPath = try self.getExecutableOnPath(name: "swiftlint", workingDirectory: workspaceRootDirectory)
             let task = NSTask()
             task.launchPath = swiftlintPath
-            task.arguments = ["autocorrect", "--path", filePath]
+            task.arguments = ["autocorrect", "--format", "--path", filePath]
             task.currentDirectoryPath = workspaceRootDirectory
             task.launch()
             task.waitUntilExit()


### PR DESCRIPTION
I only added the new --format option. Works well.
